### PR TITLE
Add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Death By Gravity Studio
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# GPT Actions for Unity
+
+**GPT Actions** is a Unity Editor extension that adds an AI powered chat window capable of executing editor actions through OpenAI's GPT models. The package exposes a collection of tools that let the assistant create and modify assets, generate scripts, query project information and automate common Unity workflows.
+
+## Installation
+
+Add the package to your project's `manifest.json` using the Git URL:
+
+```json
+"com.deathbygravitystudio.gptactions": "https://github.com/denchi/UnityGPTActions.git"
+```
+
+All required dependencies, including `com.deathbygravitystudio.environment`, will be fetched automatically.
+
+## Setup API Keys
+
+Create a file named `.env` inside your project's `Assets/StreamingAssets` folder and define your API keys:
+
+```
+OPENAI_API_KEY=<your_openai_key>
+SERP_API_KEY=<optional_serpapi_key>
+```
+
+The OpenAI key is required for chatting with the assistant. The optional SerpAPI key enables actions that search the internet.
+
+## Usage
+
+1. Open the **AI Chat** window from the Unity menu: `Window > AI Chat`.
+2. Type a prompt or choose one of the suggested templates. The assistant will respond and may execute tool calls to modify your project.
+3. Actions include creating prefabs, generating scripts and shaders, adjusting serialized fields, querying assets, managing packages and more.
+
+Chat and tool call history is stored between sessions so you can continue a conversation after closing the editor.
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "email": "contact@deathbygravitystudio.com",
     "url": "https://deathbygravitystudio.com"
   },
+  "license": "MIT",
   "keywords": [ "ai", "unity", "editor", "tooling", "automation", "gpt" ],
   "dependencies": {
     "com.unity.nuget.newtonsoft-json": "3.0.1",


### PR DESCRIPTION
## Summary
- document licensing by adding MIT license file
- reference MIT license in README
- specify license field in `package.json`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847d6a042bc832ea77007374e088091