### PR TITLE
Fix Unity CI package setup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,13 +11,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: game-ci/unity-test-runner@v2
+      - name: Move package out of root
+        run: |
+          mkdir _pkg
+          shopt -s dotglob extglob
+          mv !(_pkg) _pkg/
+      - uses: game-ci/unity-test-runner@v4
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
         with:
-          projectPath: .
+          projectPath: _pkg
           unityVersion: 2021.2.3f1
           testMode: EditMode
           packageMode: true


### PR DESCRIPTION
## Summary
- move package into a temporary folder before running Unity tests
- update the Unity test runner to v4 and set path to the temporary folder

## Testing
- `npm test` *(fails: Missing script)*
- `dotnet test` *(fails: command not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6852642f73f8832e968a47e0ede1a377