### PR TITLE
Switch to OpenAI responses API

### DIFF
--- a/Editor/ChatEditorWindow.cs
+++ b/Editor/ChatEditorWindow.cs
@@ -871,7 +871,7 @@ public partial class ChatEditorWindow : EditorWindow
             throw new Exception($"OpenAI key is not set. Please set the OPENAI_API_KEY environment variable.");
         }
         
-        _api = new LegacyOpenAIApiService(key: apiKey);
+        _api = new OpenAIResponsesApiService(key: apiKey);
         _imagesApi = new OpenAIImageServiceApi(key: apiKey);
         _indexingApi = new DeepSearchClient(ChatSettings.instance.SearchApiHost, ChatSettings.instance.SearchApiPythonPath);
     }

--- a/Runtime/Api/OpenAIResponsesApiService.cs
+++ b/Runtime/Api/OpenAIResponsesApiService.cs
@@ -130,7 +130,11 @@ namespace GPTUnity.Api
         {
             return new GPTMessage.Content
             {
-                type = content.type,
+                type = content.type switch
+                {
+                    "text" => "input_text",
+                    _ => content.type
+                },
                 text = content.text,
                 input_audio = content.input_audio
             };

--- a/Runtime/Api/OpenAIResponsesApiService.cs
+++ b/Runtime/Api/OpenAIResponsesApiService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
@@ -10,125 +11,161 @@ using UnityEngine;
 
 namespace GPTUnity.Api
 {
-    // public class ResponsesOpenAIApiService : IGPTServiceApi
-    // {
-    //     private readonly int _maxTokens;
-    //     private readonly string _key;
-    //     
-    //     public ResponsesOpenAIApiService(string key, int maxTokens = 8192)
-    //     {
-    //         _key = key;
-    //         _maxTokens = maxTokens;
-    //     }
-    //
-    //     public IReadOnlyList<string> Models => new List<string>
-    //     {
-    //         "gpt-3.5-turbo", 
-    //         "gpt-4", 
-    //         "gpt-4o", 
-    //         "gpt-4.1", 
-    //         "gpt-4.1-mini", 
-    //         "gpt-4.1-nano"
-    //     };
-    //
-    //     public async Task<GPTFunctionResponse> Chat(IReadOnlyCollection<GPTMessage> messages, string model, object[] tools = null, object schema = null)
-    //     {
-    //         var client = new HttpClient();
-    //         var url = "https://api.openai.com/v1/responses";
-    //
-    //         // Convert GPTMessage list to input array
-    //         var input = new JArray();
-    //         foreach (var msg in messages)
-    //         {
-    //             input.Add(new JObject
-    //             {
-    //                 ["type"] = "input_text",
-    //                 ["role"] = msg.role, // "user", "system", etc.
-    //                 ["text"] = msg.content
-    //             });
-    //         }
-    //
-    //         var requestBody = new JObject
-    //         {
-    //             ["model"] = model,
-    //             ["input"] = input
-    //         };
-    //
-    //         if (tools != null)
-    //         {
-    //             requestBody["tools"] = JToken.FromObject(tools);
-    //         }
-    //         
-    //         if (schema != null)
-    //         {
-    //             requestBody["response_format"] = JToken.FromObject(new
-    //             {
-    //                 type = "json_schema",
-    //                 json_schema = JToken.FromObject(schema)
-    //             });
-    //         }
-    //
-    //         var requestJson = requestBody.ToString();
-    //         var content = new StringContent(requestJson, Encoding.UTF8, "application/json");
-    //         client.DefaultRequestHeaders.Add("Authorization", $"Bearer {_key}");
-    //
-    //         var response = await client.PostAsync(url, content);
-    //         var responseJson = await response.Content.ReadAsStringAsync();
-    //
-    //         if (responseJson.Contains("\"error\""))
-    //         {
-    //             throw new Exception(responseJson);
-    //         }
-    //
-    //         // Parse using the new model
-    //         var parsed = JsonConvert.DeserializeObject<GPTResponseApiResponse>(responseJson);
-    //
-    //         // Convert to legacy-style response so your app can still use it
-    //         return new GPTFunctionResponse
-    //         {
-    //             choices = new List<GPTChoice>
-    //             {
-    //                 new GPTChoice
-    //                 {
-    //                     message = new GPTMessage
-    //                     {
-    //                         role = "assistant",
-    //                         content = parsed.output_text
-    //                     },
-    //                     finish_reason = FinishReason.stop
-    //                 }
-    //             }
-    //         };
-    //     }
-    //
-    //     /// <summary>
-    //     /// Calls the LLM with a given prompt and attempts to deserialize the response into the specified type.
-    //     /// </summary>
-    //     /// <param name="messages"></param>
-    //     /// <param name="model"></param>
-    //     /// <param name="schema"></param>
-    //     /// <param name="tools"></param>
-    //     /// <typeparam name="T"></typeparam>
-    //     /// <returns></returns>
-    //     /// <exception cref="Exception"></exception>
-    //     public async Task<T> Get<T>(IReadOnlyCollection<GPTMessage> messages, string model, object schema, object[] tools = null)
-    //     {
-    //         var result = await Chat(messages, model, tools, schema);
-    //         if (result.choices == null || result.choices.Count == 0)
-    //         {
-    //             throw new Exception("No choices returned from the model.");
-    //         }
-    //         
-    //         return JsonConvert.DeserializeObject<T>(result.choices[0].message.content);
-    //     }
-    //
-    //     public class GPTResponseApiResponse
-    //     {
-    //         public string id { get; set; }
-    //         public string @object { get; set; }
-    //         public string model { get; set; }
-    //         public long created { get; set; }
-    //         public string output_text { get; set; }
-    //     }
-    // }
+    public class OpenAIResponsesApiService : IGPTServiceApi
+    {
+        private readonly int _maxTokens;
+        private readonly string _key;
+
+        public OpenAIResponsesApiService(string key, int maxTokens = 8192)
+        {
+            _key = key;
+            _maxTokens = maxTokens;
+        }
+
+        public IReadOnlyList<string> Models => new List<string>
+        {
+            "gpt-5",
+            "gpt-4.1",
+            "gpt-4.1-mini",
+            "gpt-4.1-nano",
+            "gpt-4o",
+            "gpt-4",
+            "gpt-3.5-turbo"
+        };
+
+        public async Task<GPTFunctionResponse> Chat(IReadOnlyCollection<GPTMessage> messages, string model, object[] tools = null, object schema = null)
+        {
+            var client = new HttpClient();
+            var url = "https://api.openai.com/v1/responses";
+
+            var requestBody = new JObject
+            {
+                ["model"] = model,
+                ["input"] = JToken.FromObject(messages),
+                ["max_output_tokens"] = _maxTokens
+            };
+
+            if (tools != null)
+            {
+                requestBody["tool_choice"] = "auto";
+                requestBody["tools"] = JToken.FromObject(tools);
+            }
+
+            if (schema != null)
+            {
+                requestBody["response_format"] = JToken.FromObject(new
+                {
+                    type = "json_schema",
+                    json_schema = JToken.FromObject(schema)
+                });
+            }
+
+            var requestJson = JsonConvert.SerializeObject(requestBody);
+
+            var content = new StringContent(requestJson, Encoding.UTF8, "application/json");
+            client.DefaultRequestHeaders.Add("Authorization", $"Bearer {_key}");
+
+            Debug.Log($"<color=blue>[Network]</color> Sending request to {url} with model {model} and input: {requestJson}");
+
+            var response = await client.PostAsync(url, content);
+            var responseJson = await response.Content.ReadAsStringAsync();
+
+            Debug.Log($"\t<color=blue>[Network]</color> {url} => {responseJson}");
+
+            if (responseJson.Contains("\"error\""))
+            {
+                throw new Exception(responseJson);
+            }
+
+            var parsed = JsonConvert.DeserializeObject<OpenAIResponsesApiResponse>(responseJson);
+            return ConvertResponse(parsed);
+        }
+
+        public async Task<T> Get<T>(IReadOnlyCollection<GPTMessage> messages, string model, object schema, object[] tools = null)
+        {
+            var result = await Chat(messages, model, tools, schema);
+            if (result.choices == null || result.choices.Count == 0)
+            {
+                throw new Exception("No choices returned from the model.");
+            }
+
+            return JsonConvert.DeserializeObject<T>(result.choices[0].message.StringContent);
+        }
+
+        private static GPTFunctionResponse ConvertResponse(OpenAIResponsesApiResponse response)
+        {
+            if (response?.output == null || response.output.Count == 0)
+            {
+                return new GPTFunctionResponse
+                {
+                    choices = new List<GPTChoice>()
+                };
+            }
+
+            var outputMessage = response.output.First();
+
+            var gptMessage = new GPTMessage
+            {
+                role = outputMessage.role,
+                content = outputMessage.content?.Select(MapContent).ToList(),
+                tool_calls = outputMessage.tool_calls
+            };
+
+            return new GPTFunctionResponse
+            {
+                choices = new List<GPTChoice>
+                {
+                    new GPTChoice
+                    {
+                        message = gptMessage,
+                        finish_reason = MapFinishReason(response.stop_reason)
+                    }
+                }
+            };
+        }
+
+        private static FinishReason MapFinishReason(string stopReason)
+        {
+            return stopReason switch
+            {
+                "tool_call" => FinishReason.tool_calls,
+                "max_output_tokens" => FinishReason.length,
+                "content_filter" => FinishReason.content_filter,
+                "function_call" => FinishReason.function_call,
+                _ => FinishReason.stop
+            };
+        }
+
+        private static GPTMessage.Content MapContent(OpenAIResponseContent content)
+        {
+            return new GPTMessage.Content
+            {
+                type = content.type == "output_text" ? "text" : content.type,
+                text = content.text
+            };
+        }
+
+        public class OpenAIResponsesApiResponse
+        {
+            public string id { get; set; }
+            public string @object { get; set; }
+            public string model { get; set; }
+            public long created { get; set; }
+            public List<OpenAIResponseMessage> output { get; set; }
+            public string stop_reason { get; set; }
+        }
+
+        public class OpenAIResponseMessage
+        {
+            public string role { get; set; }
+            public List<OpenAIResponseContent> content { get; set; }
+            public GPTToolCall[] tool_calls { get; set; }
+        }
+
+        public class OpenAIResponseContent
+        {
+            public string type { get; set; }
+            public string text { get; set; }
+        }
+    }
 }

--- a/Runtime/Api/OpenAIResponsesApiService.cs
+++ b/Runtime/Api/OpenAIResponsesApiService.cs
@@ -128,15 +128,17 @@ namespace GPTUnity.Api
 
         private static GPTMessage.Content MapInputContent(GPTMessage.Content content)
         {
+            var mappedType = content.type switch
+            {
+                "text" => "input_text",
+                _ => content.type
+            };
+
             return new GPTMessage.Content
             {
-                type = content.type switch
-                {
-                    "text" => "input_text",
-                    _ => content.type
-                },
-                text = content.text,
-                input_audio = content.input_audio
+                type = mappedType,
+                text = mappedType == "input_text" ? content.text : null,
+                input_audio = mappedType == "input_audio" ? content.input_audio : null
             };
         }
 

--- a/Runtime/Api/OpenAIResponsesApiService.cs
+++ b/Runtime/Api/OpenAIResponsesApiService.cs
@@ -38,10 +38,17 @@ namespace GPTUnity.Api
             var client = new HttpClient();
             var url = "https://api.openai.com/v1/responses";
 
+            var serializer = JsonSerializer.Create(new JsonSerializerSettings
+            {
+                NullValueHandling = NullValueHandling.Ignore
+            });
+
+            var inputMessages = messages.Select(MapInputMessage).ToList();
+
             var requestBody = new JObject
             {
                 ["model"] = model,
-                ["input"] = JToken.FromObject(messages),
+                ["input"] = JToken.FromObject(inputMessages, serializer),
                 ["max_output_tokens"] = _maxTokens
             };
 
@@ -90,6 +97,43 @@ namespace GPTUnity.Api
             }
 
             return JsonConvert.DeserializeObject<T>(result.choices[0].message.StringContent);
+        }
+
+        private static JObject MapInputMessage(GPTMessage message)
+        {
+            var content = message.content?.Select(MapInputContent).ToList();
+
+            var payload = new JObject
+            {
+                ["role"] = message.role
+            };
+
+            if (content != null && content.Count > 0)
+            {
+                payload["content"] = JToken.FromObject(content);
+            }
+
+            if (!string.IsNullOrEmpty(message.tool_call_id))
+            {
+                payload["tool_call_id"] = message.tool_call_id;
+            }
+
+            if (!string.IsNullOrEmpty(message.name))
+            {
+                payload["name"] = message.name;
+            }
+
+            return payload;
+        }
+
+        private static GPTMessage.Content MapInputContent(GPTMessage.Content content)
+        {
+            return new GPTMessage.Content
+            {
+                type = content.type,
+                text = content.text,
+                input_audio = content.input_audio
+            };
         }
 
         private static GPTFunctionResponse ConvertResponse(OpenAIResponsesApiResponse response)


### PR DESCRIPTION
## Summary
- replace the chat completions client with an OpenAI responses API integration that maps responses into existing GPT structures
- update the Unity chat editor window to use the new responses-based service and expose newer model options

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ac3fb6c00832ebdbd83ec83d0b0b0)